### PR TITLE
Cleaning up BuiltInTemplatePackageProvider + PackageInspector

### DIFF
--- a/Source/DotnetNewUI/NuGet/BuiltInTemplatePackageProvider.cs
+++ b/Source/DotnetNewUI/NuGet/BuiltInTemplatePackageProvider.cs
@@ -6,75 +6,76 @@ using global::NuGet.Versioning;
 /// <summary>
 /// Returns list of *.nupkg files from C:\Program Files\dotnet\templates\x.x.x.x\ (on Windows) to be installed.
 /// <para>
-/// Based on <see href="https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-new/BuiltInTemplatePackageProvider.cs">'dotnet new' source code</see>.
+/// Inspired by <see href="https://github.com/dotnet/sdk/blob/main/src/Cli/dotnet/commands/dotnet-new/BuiltInTemplatePackageProvider.cs">'dotnet new' source code</see>.
 /// </para>
 /// </summary>
 internal static class BuiltInTemplatePackageProvider
 {
     public static async Task<IReadOnlyList<string>> GetAllTemplatePackagesAsync(DotNetCli dotNetCli)
     {
-        var templateFolders = await GetTemplateFoldersAsync(dotNetCli).ConfigureAwait(false);
+        var (sdkVersion, sdkInstallDir) = await GetCurrentSdkInfoAsync(dotNetCli).ConfigureAwait(false);
 
-        return templateFolders
+        return GetTemplateFolders(sdkVersion, sdkInstallDir)
+            .Where(folder => Directory.Exists(folder))
             .SelectMany(folder => Directory.EnumerateFiles(folder, "*.nupkg", SearchOption.TopDirectoryOnly))
             .ToList();
     }
 
-    private static async Task<IEnumerable<string>> GetTemplateFoldersAsync(DotNetCli dotNetCli)
+    private static async Task<(SemanticVersion Version, string InstallDir)> GetCurrentSdkInfoAsync(DotNetCli dotNetCli)
     {
         var sdks = await dotNetCli.ListSdksAsync().ConfigureAwait(false);
         var currentSdkVersion = await dotNetCli.GetSdkVersionAsync().ConfigureAwait(false);
+        return sdks.Single(x => x.SdkVersion == currentSdkVersion);
+    }
 
-        var (sdkVersion, sdkInstallDir) = sdks.Single(x => x.SdkVersion == currentSdkVersion);
-        var dotnetRootPath = Path.GetDirectoryName(sdkInstallDir)!;
+    private static IEnumerable<string> GetTemplateFolders(SemanticVersion sdkVersion, string sdkInstallDir)
+    {
+        var dotnetRootDir = BuiltInTemplatePackageProviderHelper.GetDotnetRootDirectory(sdkInstallDir);
 
         var templateFolders = new List<string>();
 
-        var globalTemplateFolders = GetGlobalTemplateFolders(dotnetRootPath, sdkVersion);
+        var globalTemplateFolders = GetGlobalTemplateFolders(dotnetRootDir, sdkVersion);
         if (globalTemplateFolders is not null)
         {
             templateFolders.AddRange(globalTemplateFolders);
         }
 
-        var sdkTemplateFolder = GetSdkTemplateFolder(dotnetRootPath, sdkVersion);
-        if (sdkTemplateFolder is not null)
-        {
-            templateFolders.Add(sdkTemplateFolder);
-        }
+        templateFolders.Add(BuiltInTemplatePackageProviderHelper.GetSdkTemplateDir(dotnetRootDir, sdkVersion));
 
         return templateFolders;
     }
 
-    private static IEnumerable<string>? GetGlobalTemplateFolders(string dotnetRootPath, SemanticVersion sdkVersion)
+    private static IEnumerable<string>? GetGlobalTemplateFolders(string dotnetRootDir, SemanticVersion sdkVersion)
     {
-        var templatesRootFolder = Path.Combine(dotnetRootPath, "templates");
+        var templatesRootDir = BuiltInTemplatePackageProviderHelper.GetGlobalTemplatesRootDir(dotnetRootDir);
 
-        if (Directory.Exists(templatesRootFolder))
+        if (Directory.Exists(templatesRootDir))
         {
-            var templateDirs = Directory
-                .EnumerateDirectories(templatesRootFolder, "*.*", SearchOption.TopDirectoryOnly)
-                .Select(path => (Path: path, Version: SemanticVersion.Parse(Path.GetFileName(path))))
-                .OrderBy(x => x.Version)
-                .TakeWhile(x => x.Version <= sdkVersion)
-                .GroupBy(x => new Version(x.Version.Major, x.Version.Minor))
-                .Select(g => g.Last())
-                .Select(x => x.Path);
-
-            return templateDirs;
+            var templateVersionDirs = Directory.EnumerateDirectories(templatesRootDir, "*.*", SearchOption.TopDirectoryOnly);
+            return BuiltInTemplatePackageProviderHelper.SelectAppropriateTemplateDirs(templateVersionDirs, sdkVersion);
         }
 
         return null;
     }
 
-    private static string? GetSdkTemplateFolder(string dotnetRootPath, SemanticVersion sdkVersion)
+    internal static class BuiltInTemplatePackageProviderHelper
     {
-        var templatesDir = Path.Combine(dotnetRootPath, "sdk", sdkVersion.ToNormalizedString(), "templates");
+        public static string GetDotnetRootDirectory(string sdkInstallDir)
+            => Path.GetDirectoryName(sdkInstallDir)!;
 
-        if (Directory.Exists(templatesDir))
-        {
-            return templatesDir;
-        }
+        public static string GetGlobalTemplatesRootDir(string dotnetRootDir)
+            => Path.Combine(dotnetRootDir, "templates");
 
-        return null;
+        public static string GetSdkTemplateDir(string dotnetRootDir, SemanticVersion sdkVersion)
+            => Path.Combine(dotnetRootDir, "sdk", sdkVersion.ToNormalizedString(), "templates");
+
+        public static IEnumerable<string> SelectAppropriateTemplateDirs(IEnumerable<string> templateVersionDirs, SemanticVersion sdkVersion)
+            => templateVersionDirs
+                .Select(dir => (Dir: dir, Version: SemanticVersion.Parse(Path.GetFileName(dir))))
+                .OrderBy(x => x.Version)
+                .TakeWhile(x => x.Version <= sdkVersion)
+                .GroupBy(x => new Version(x.Version.Major, x.Version.Minor))
+                .Select(g => g.Last())
+                .Select(x => x.Dir);
     }
 }

--- a/Source/DotnetNewUI/NuGet/BuiltInTemplatePackageProvider.cs
+++ b/Source/DotnetNewUI/NuGet/BuiltInTemplatePackageProvider.cs
@@ -75,7 +75,6 @@ internal static class BuiltInTemplatePackageProvider
                 .OrderBy(x => x.Version)
                 .TakeWhile(x => x.Version <= sdkVersion)
                 .GroupBy(x => new Version(x.Version.Major, x.Version.Minor))
-                .Select(g => g.Last())
-                .Select(x => x.Dir);
+                .Select(g => g.Last().Dir);
     }
 }

--- a/Source/DotnetNewUI/NuGet/PackageInspector.cs
+++ b/Source/DotnetNewUI/NuGet/PackageInspector.cs
@@ -7,112 +7,160 @@ using System.Xml.Linq;
 
 public static class PackageInspector
 {
-    private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web)
-    {
-        AllowTrailingCommas = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-    };
-
     public static IReadOnlyList<CompositeTemplateManifest> GetTemplateManifestsFromPackage(string packagePath, bool isBuiltIn)
     {
-        var (packageName, packageVersion) = GetPackageNameAndVersion(packagePath);
+        var (packageName, packageVersion) = PackageInspectorHelper.GetPackageNameAndVersion(packagePath);
 
         using var file = File.OpenRead(packagePath);
         using var archive = new ZipArchive(file);
 
-        var metadataFilePath = $"{packageName}.nuspec";
-        var metadataFile = archive.Entries.Single(x => x.FullName.Equals(metadataFilePath, StringComparison.OrdinalIgnoreCase));
+        var packageManifest = GetPackageManifest(archive, packageName);
+        var base64PackageIcon = TryGetBase64PackageIcon(archive, packageManifest.Metadata.Icon);
 
-        var metadata = GetPackageMetadata(metadataFile!);
-        var base64PackageIcon = metadata.Metadata!.Icon is string packageIconPath ? GetBase64PackageIcon(archive, packageIconPath) : null;
-
-        var templateManifestRegex = new Regex("^(content/)?(?<template>.*)/\\.template\\.config/template\\.json$");
-
-        var templateManifests = archive.Entries
-            .Select(x => templateManifestRegex.Match(x.FullName) is { Success: true } ? x : null)
-            .Where(x => x is not null)
-            .Select(x => x!)
-            .Select(x =>
+        return PackageInspectorHelper
+            .GetTemplateConfigDirs(archive.Entries.Select(x => x.FullName))
+            .Select(templateConfigDir =>
             {
-                var parentDirectory = Path.GetDirectoryName(x.FullName)!;
+                var templateManifest = TryGetTemplateManifest(archive, templateConfigDir);
+                var ideHostManifest = TryGetIdeHostManifest(archive, templateConfigDir);
+                var base64TemplateIcon = TryGetBase64TemplateIcon(archive, templateConfigDir, ideHostManifest?.Icon);
 
-                var templateManifest = GetTemplateManifest(x);
-                var ideHostManifest = TryGetIdeHostManifest(archive, parentDirectory);
-                var base64TemplateIcon = ideHostManifest?.Icon is string templateIconPath ? GetBase64TemplateIcon(archive, parentDirectory, ideHostManifest.Icon) : null;
-
-                return new CompositeTemplateManifest(packageName, packageVersion, base64TemplateIcon ?? base64PackageIcon, isBuiltIn, templateManifest, ideHostManifest);
+                // templateManifest! -> possibly forcing null into a non-nullable property, but filtering those cases out immediately
+                // it makes it easier for the rest of app, so we don't have to check for nulls
+                return new CompositeTemplateManifest(packageName, packageVersion, base64TemplateIcon ?? base64PackageIcon, isBuiltIn, templateManifest!, ideHostManifest);
             })
+            .Where(x => x.TemplateManifest is not null)
             .ToList();
-
-        return templateManifests;
     }
 
-    public static (string PackageName, string Version) GetPackageNameAndVersion(string filePath)
+    private static PackageManifest GetPackageManifest(ZipArchive archive, string packageName)
     {
-        var fileName = Path.GetFileName(filePath);
-
-        var regex = new Regex("^(?<packagename>.*)\\.(?<version>\\d*\\.\\d*\\.\\d*-?.*)\\.nupkg$");
-        var match = regex.Match(fileName);
-        var packageName = match.Groups["packagename"].Value;
-        var version = match.Groups["version"].Value;
-
-        return (packageName, version);
+        var packageManifestPath = PackageInspectorHelper.GetPackageManifestPath(packageName);
+        var packageManifestFile = archive.Entries.Single(x => string.Equals(x.FullName, packageManifestPath, StringComparison.OrdinalIgnoreCase));
+        using var packageManifestFileStream = packageManifestFile.Open();
+        return PackageInspectorHelper.ParseXmlPackageManifest(packageManifestFileStream);
     }
 
-    private static PackageManifest GetPackageMetadata(ZipArchiveEntry metadataFile)
+    private static TemplateManifest? TryGetTemplateManifest(ZipArchive archive, string templateConfigDir)
     {
-        using var metadataFileStream = metadataFile.Open();
-        var xDoc = XDocument.Load(metadataFileStream);
-        var packageElement = xDoc.Document!.Elements().First();
-        var metadataElement = packageElement!.Elements().First();
-        var id = metadataElement!.Elements().First(e => e.Name.LocalName == "id").Value;
-        var version = metadataElement!.Elements().First(e => e.Name.LocalName == "version").Value;
-        var icon = metadataElement!.Elements().FirstOrDefault(e => e.Name.LocalName == "icon")?.Value;
-        return new PackageManifest(new PackageMetadata(id, version, icon));
-    }
-
-    private static TemplateManifest GetTemplateManifest(ZipArchiveEntry templateFile)
-    {
-        using var templateFileStream = templateFile.Open();
-        var templateFileContent = JsonSerializer.Deserialize<TemplateManifest>(templateFileStream, JsonSerializerOptions);
-        return templateFileContent!;
-    }
-
-    private static TemplateIdeHostManifest? TryGetIdeHostManifest(ZipArchive archive, string parentDirectory)
-    {
-        var ideHostFilePath = Path.Combine(parentDirectory, "ide.host.json").Replace("\\", "/");
-        var ideHostFile = archive.Entries.FirstOrDefault(e => e.FullName == ideHostFilePath);
-        if (ideHostFile is not null)
+        var templateManifestPath = PackageInspectorHelper.GetTemplateManifestPath(templateConfigDir);
+        var templateManifestFile = archive.Entries.SingleOrDefault(x => string.Equals(x.FullName, templateManifestPath, StringComparison.OrdinalIgnoreCase));
+        if (templateManifestFile is not null)
         {
-            using var ideHostFileStream = ideHostFile.Open();
-            var ideHostFileContent = JsonSerializer.Deserialize<TemplateIdeHostManifest>(ideHostFileStream, JsonSerializerOptions)!;
-
-            return ideHostFileContent;
+            using var templateManifestFileStream = templateManifestFile.Open();
+            return PackageInspectorHelper.ParseJsonTemplateManifest(templateManifestFileStream);
         }
 
         return null;
     }
 
-    private static string GetBase64TemplateIcon(ZipArchive archive, string parentDirectory, string relativeIconPath)
+    private static TemplateIdeHostManifest? TryGetIdeHostManifest(ZipArchive archive, string templateConfigDir)
     {
-        var iconFilePath = Path.Combine(parentDirectory, relativeIconPath).Replace("\\", "/");
-        return GetBase64Icon(archive, iconFilePath);
+        var ideHostManifestPath = PackageInspectorHelper.GetIdeHostManifestPath(templateConfigDir);
+        var ideHostManifestFile = archive.Entries.SingleOrDefault(x => string.Equals(x.FullName, ideHostManifestPath, StringComparison.OrdinalIgnoreCase));
+        if (ideHostManifestFile is not null)
+        {
+            using var ideHostManifestFileStream = ideHostManifestFile.Open();
+            return PackageInspectorHelper.ParseJsonIdeHostManifest(ideHostManifestFileStream);
+        }
+
+        return null;
     }
 
-    private static string GetBase64PackageIcon(ZipArchive archive, string iconPath)
-        => GetBase64Icon(archive, iconPath);
-
-    private static string GetBase64Icon(ZipArchive archive, string iconPath)
+    private static string? TryGetBase64PackageIcon(ZipArchive archive, string? iconPath)
     {
-        var iconFile = archive.Entries.Single(e => e.FullName == iconPath);
-        var iconFileType = Path.GetExtension(iconPath)[1..];
+        if (iconPath is not null)
+        {
+            var packageIconFile = archive.Entries.Single(x => string.Equals(x.FullName, iconPath, StringComparison.OrdinalIgnoreCase));
+            using var packageIconFileStream = packageIconFile.Open();
+            return PackageInspectorHelper.GetBase64Icon(packageIconFileStream, packageIconFile.Name);
+        }
 
-        using var iconFileStream = iconFile.Open();
-        using var memoryStream = new MemoryStream();
-        iconFileStream.CopyTo(memoryStream);
-        var bytes = memoryStream.ToArray();
-        var base64Icon = Convert.ToBase64String(bytes);
+        return null;
+    }
 
-        return $"data:image/{iconFileType};base64,{base64Icon}";
+    private static string? TryGetBase64TemplateIcon(ZipArchive archive, string templateConfigDir, string? templateIconRelativePath)
+    {
+        if (templateIconRelativePath is not null)
+        {
+            var templateIconPath = PackageInspectorHelper.GetTemplateIconPath(templateConfigDir, templateIconRelativePath);
+            var templateIconFile = archive.Entries.Single(x => string.Equals(x.FullName, templateIconPath, StringComparison.OrdinalIgnoreCase));
+            return PackageInspectorHelper.GetBase64Icon(templateIconFile.Open(), templateIconFile.Name);
+        }
+
+        return null;
+    }
+
+    internal static class PackageInspectorHelper
+    {
+        private static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web)
+        {
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+        };
+
+        public static (string PackageName, string Version) GetPackageNameAndVersion(string filePath)
+        {
+            var fileName = Path.GetFileName(filePath);
+
+            var regex = new Regex("^(?<packagename>.*)\\.(?<version>\\d*\\.\\d*\\.\\d*-?.*)\\.nupkg$");
+            var match = regex.Match(fileName);
+            var packageName = match.Groups["packagename"].Value;
+            var version = match.Groups["version"].Value;
+
+            return (packageName, version);
+        }
+
+        public static string GetPackageManifestPath(string packageName)
+            => $"{packageName}.nuspec";
+
+        public static IEnumerable<string> GetTemplateConfigDirs(IEnumerable<string> archive)
+        {
+            var templateConfigDirRegex = new Regex("^(content/)?(?<template>.*)/\\.template\\.config");
+
+            return archive
+                .Select(x => templateConfigDirRegex.Match(x))
+                .Where(x => x.Success)
+                .Select(x => x.Value)
+                .Distinct();
+        }
+
+        public static string GetTemplateManifestPath(string templateConfigDir)
+            => Path.Combine(templateConfigDir, "template.json").Replace("\\", "/");
+
+        public static string GetIdeHostManifestPath(string templateConfigDir)
+            => Path.Combine(templateConfigDir, "ide.host.json").Replace("\\", "/");
+
+        public static string GetTemplateIconPath(string templateConfigDir, string iconRelativePath)
+            => Path.Combine(templateConfigDir, iconRelativePath).Replace("\\", "/");
+
+        public static PackageManifest ParseXmlPackageManifest(Stream stream)
+        {
+            var xDoc = XDocument.Load(stream);
+            var packageElement = xDoc.Document!.Elements().First();
+            var metadataElement = packageElement!.Elements().First();
+            var id = metadataElement!.Elements().First(e => string.Equals(e.Name.LocalName, "id", StringComparison.OrdinalIgnoreCase)).Value;
+            var version = metadataElement!.Elements().First(e => string.Equals(e.Name.LocalName, "version", StringComparison.OrdinalIgnoreCase)).Value;
+            var icon = metadataElement!.Elements().FirstOrDefault(e => string.Equals(e.Name.LocalName, "icon", StringComparison.OrdinalIgnoreCase))?.Value;
+            return new PackageManifest(new PackageMetadata(id, version, icon));
+        }
+
+        public static TemplateManifest ParseJsonTemplateManifest(Stream stream)
+            => JsonSerializer.Deserialize<TemplateManifest>(stream, JsonSerializerOptions)!;
+
+        public static TemplateIdeHostManifest ParseJsonIdeHostManifest(Stream stream)
+            => JsonSerializer.Deserialize<TemplateIdeHostManifest>(stream, JsonSerializerOptions)!;
+
+        public static string GetBase64Icon(Stream stream, string fileName)
+        {
+            var fileType = Path.GetExtension(fileName);
+
+            using var memoryStream = new MemoryStream();
+            stream.CopyTo(memoryStream);
+            var bytes = memoryStream.ToArray();
+            var base64Icon = Convert.ToBase64String(bytes);
+
+            return $"data:image/{fileType};base64,{base64Icon}";
+        }
     }
 }

--- a/Source/DotnetNewUI/Services/PackagesService.cs
+++ b/Source/DotnetNewUI/Services/PackagesService.cs
@@ -42,12 +42,12 @@ public class PackagesService : IPackagesService
         public static IReadOnlyList<NuGetPackageInfo> MergeResults(IReadOnlyList<NuGetPackageInfo> onlinePackages, IReadOnlyList<string> builtInPackagePaths, IReadOnlyList<string> installedPackagePaths)
         {
             var builtInTemplateDictionary = builtInPackagePaths
-                .Select(x => PackageInspector.GetPackageNameAndVersion(x))
+                .Select(x => PackageInspector.PackageInspectorHelper.GetPackageNameAndVersion(x))
                 .GroupBy(x => x.PackageName)
                 .ToDictionary(g => g.Key.ToLowerInvariant(), g => g.Select(x => x.Version).Max());
 
             var installedTemplateDictionary = installedPackagePaths
-                .Select(x => PackageInspector.GetPackageNameAndVersion(x))
+                .Select(x => PackageInspector.PackageInspectorHelper.GetPackageNameAndVersion(x))
                 .GroupBy(x => x.PackageName)
                 .ToDictionary(g => g.Key.ToLowerInvariant(), g => g.Select(x => x.Version).Max());
 


### PR DESCRIPTION
Refactoring `BuiltInTemplatePackageProvider` + `PackageInspector` for better readability and testability